### PR TITLE
fix password flow (w/ client credentials)

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -62,7 +62,7 @@ module.exports = function(config) {
     if (method == 'GET') options.qs   = params;
 
     // Enable the system to send authorization params in the body (for example github does not require to be in the header)
-    if (method != 'GET' && options.form && !params.password) {
+    if (method != 'GET' && options.form) {
       options.form.client_id = config.clientID;
       options.form[config.clientSecretParameterName] = config.clientSecret;
     }

--- a/test/password.js
+++ b/test/password.js
@@ -10,7 +10,7 @@ describe('oauth2.password',function() {
   describe('#getToken',function() {
 
     beforeEach(function(done) {
-      var params = { 'username': 'alice', 'password': 'secret', 'grant_type': 'password' };
+      var params = { 'username': 'alice', 'password': 'secret', 'grant_type': 'password', 'client_id': 'client-id', 'client_secret': 'client-secret' };
       request = nock('https://example.org:443').post('/oauth/token', qs.stringify(params)).replyWithFile(200, __dirname + '/fixtures/access_token.json');
       done();
     })


### PR DESCRIPTION
The previous mock server was completely ignoring client credentials.

The updated test would fail and expose the bug - without a small
change in core.js.

(If I'm missing something, thanks for any explanation).

