### PR TITLE
Optional headers on requests and response in callback

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -89,7 +89,7 @@ module.exports = function(config) {
     catch(e) { /* The OAuth2 server does not return a valid JSON'); */ }
 
     if (response.statusCode >= 400) return callback(body || new errors.HTTPError(response.statusCode), null)
-    callback(error, body);
+    callback(error, body, response);
   }
 
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -46,6 +46,10 @@ module.exports = function(config) {
       options.headers = { 'Authorization': 'Basic ' + new Buffer(config.clientID + ':' + config.clientSecret).toString('base64') }
     else
       options.headers = {}
+      
+    if (config.headers instanceof Object)
+      for(var header in config.headers)
+        options.headers[header]=config.headers[header];
 
     if (config.ca)
       options.ca = config.ca;


### PR DESCRIPTION
Some servers require headers like User-Agent

Also the response object contains information like rel links in the links header (for navigating paginated resources - GitHub uses it)

Further info in each commit