### PR TITLE
Support additional params in refresh access-token flow

### DIFF
--- a/lib/client/access-token.js
+++ b/lib/client/access-token.js
@@ -27,13 +27,19 @@ module.exports = function(config) {
   //
   // ### Refresh the access token
   //
+  // * `params` - An optional argument for additional API request params.
   // * `callback` - The callback function returning the results.
   // An error object is passed as first argument and the new OAuth2.AccessToken
   // as last.
   //
-  function refresh(callback) {
-    var params = { grant_type: 'refresh_token', refresh_token: this.token.refresh_token };
-    var that = this;
+  function refresh(params, callback) {
+    if (typeof params === 'function') {
+      callback = params;
+      params = undefined;
+    }
+    params = params || {};
+    params.grant_type = 'refresh_token';
+    params.refresh_token = this.token.refresh_token;
 
     return core.api('POST', config.tokenPath, params).then(this.create).nodeify(callback);
   }

--- a/test/access_token.js
+++ b/test/access_token.js
@@ -9,6 +9,7 @@ var request,
     error, errorPromise,
     tokenConfig = { 'code': 'code', 'redirect_uri': 'http://callback.com' },
     refreshConfig = { 'grant_type': 'refresh_token', refresh_token: 'ec1a59d298', 'client_id': 'client-id', 'client_secret': 'client-secret' },
+    refreshWithAdditionalParamsConfig = { 'scope': 'TESTING_EXAMPLE_SCOPES', 'grant_type': 'refresh_token', refresh_token: 'ec1a59d298', 'client_id': 'client-id', 'client_secret': 'client-secret' },
     revokeConfig = { 'token': 'ec1a59d298', 'token_type_hint': 'refresh_token', 'client_id': 'client-id', 'client_secret': 'client-secret' },
     oauthConfig = { 'code': 'code', 'redirect_uri': 'http://callback.com', 'grant_type': 'authorization_code', 'client_id': 'client-id', 'client_secret': 'client-secret' };
 
@@ -115,7 +116,47 @@ describe('oauth2.accessToken',function() {
     it('returns a new oauth2.accessToken as result of promise api', function() {
       resultPromise.token.should.have.property('access_token');
     });
-  })
+  });
+
+  describe('when refreshes token with additional params', function() {
+
+    beforeEach(function(done) {
+      request = nock('https://example.org:443')
+        .post('/oauth/token', qs.stringify(refreshWithAdditionalParamsConfig))
+        .times(2)
+        .replyWithFile(200, __dirname + '/fixtures/access_token.json');
+      done();
+    });
+
+    beforeEach(function(done) {
+      result = null;
+      token.refresh({scope: 'TESTING_EXAMPLE_SCOPES'}, function(e, r) {
+        error = e; result = r; done();
+      });
+    });
+
+    beforeEach(function(done) {
+      resultPromise = null;
+      errorPromise = null;
+
+      token.refresh({scope: 'TESTING_EXAMPLE_SCOPES'})
+        .then(function (r) { resultPromise = r; })
+        .catch(function (e) { errorPromise = e; })
+        .finally(done);
+    });
+
+    it('makes the HTTP request', function() {
+      request.isDone();
+    });
+
+    it('returns a new oauth2.accessToken as result of callback api',function() {
+      result.token.should.have.property('access_token');
+    });
+
+    it('returns a new oauth2.accessToken as result of promise api', function() {
+      resultPromise.token.should.have.property('access_token');
+    });
+  });
 
   describe('#revoke',function() {
 


### PR DESCRIPTION
Some APIs require additional properties in certain OAuth requests. [Microsoft Office 365](https://msdn.microsoft.com/office/office365/HowTo/authentication-v2-protocols#DataTables_Table_7_wrapper), for example, requires an additional `scope` property to re-request the proper scopes for the new access token.  This requirement by Microsoft makes this otherwise awesome library unusable in its current state.

This change is non-breaking, and adds support for adding additional params to the `refresh()` access token call. If only a callback is provided, the function continues to behave as if no additional params were provided.