### PR TITLE
Feature/remove querystring dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - 0.11
   - 0.10
+  - 0.12
+  - 4

--- a/package.json
+++ b/package.json
@@ -12,10 +12,9 @@
     "node": "~0.8.x"
   },
   "dependencies": {
-    "request": "~2.12.0",
-    "querystring": "~0.1.0",
+    "bluebird": "^2.10.1",
     "date-utils": "~1.2.12",
-    "bluebird": "^2.10.1"
+    "request": "~2.12.0"
   },
   "devDependencies": {
     "doctoc": "^0.15.0",


### PR DESCRIPTION
This module have the npm "querystring" module, but not sure why it is even needed. This PR remove this module from the list of dependencies. Also add some travis-ci node environments to verify it is not breaking anything.

@andreareginato There is any reason why this module it´s included here? Let me know if there is a known problem or concern about removing this