### PR TITLE
Fixed error on token rejection when the body is present.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -85,7 +85,7 @@ module.exports = function(config) {
     catch(e) { /* The OAuth2 server does not return a valid JSON'); */ }
 
     if (response.statusCode >= 400 && body) {
-      return Promise.resolve(body).nodeify(callback);
+      return Promise.reject(body).nodeify(callback);
     }else if(response.statusCode >= 400 && !body) {
       return Promise.reject(new errors.HTTPError(response.statusCode)).nodeify(callback);
     }


### PR DESCRIPTION
There is a bug that was introduced by #46, in which when the OAuth2 server returned an body response with a 4xx error, the promise chain (and callback) is fulfilled instead of being rejected.

@andreareginato I´ll merge this, since it´s a huge error (made by me). Along with other features already merged into develop, I will release a new version of this module (0.4.0).