### PR TITLE
Feature/provide error information

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -89,10 +89,8 @@ module.exports = function (config) {
       /* The OAuth2 server does not return a valid JSON */
     }
 
-    if (response.statusCode >= 400 && body) {
-      return Promise.reject(body).nodeify(callback);
-    } else if (response.statusCode >= 400 && !body) {
-      return Promise.reject(new errors.HTTPError(response.statusCode)).nodeify(callback);
+    if (response.statusCode >= 400) {
+      return Promise.reject(new errors.HTTPError(response.statusCode, body)).nodeify(callback);
     }
 
     return Promise.resolve(body).nodeify(callback);

--- a/lib/error.js
+++ b/lib/error.js
@@ -49,13 +49,14 @@ var statusCodes = {
  * @return {Object} HttpError constructor
  */
 module.exports = function () {
-  function HTTPError(status) {
+  function HTTPError(status, context) {
     Error.call(this);
     Error.captureStackTrace(this, this.constructor);
 
     this.name = this.constructor.name;
     this.status = status;
     this.message = statusCodes[status];
+    this.context = context || null;
   }
 
   HTTPError.prototype = Object.create(HTTPError.prototype);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "test": "mocha ",
     "lint": "eslint lib/**",
-    "test-watch": "DEBUG=true mocha --watch",
+    "test-watch": "mocha --watch --reporter=spec",
     "docs-gen": "doctoc README.md --github --no-title"
   },
   "licenses": [


### PR DESCRIPTION
This PR solves the issue described in #28, but using other approach. Due the current way by which this module "rejects" a response when there is an error (and a body is available), we are not able to know what the actual response status code is.

This changes, wraps every ```rejected``` response with an ```HTTPError``` class. So the logic is as the following:

1. If a response is rejected (4xx, 5xx) and there is a `body` available, the error object, will have a ```context``` property which will contain that body.
2. If a response is rejected, but there isn´t any body in the response, then the library continue to work the same. An error object will be returned with the property ```context``` set to null.
3. If the response is correct (2xx), then the response is resolved.


**Currently:**
```js
    if (response.statusCode >= 400 && body) {
      return Promise.reject(body).nodeify(callback);
    } else if (response.statusCode >= 400 && !body) {
      return Promise.reject(new errors.HTTPError(response.statusCode)).nodeify(callback);
    }
```

**Now:**

```js
    if (response.statusCode >= 400) {
      return Promise.reject(new errors.HTTPError(response.statusCode, body)).nodeify(callback);
    }
```

For details on how this changes were implemented see the diff. Also test cases were added to allow to test the new behavior.

Please if you have time, review this changes and let me know what you think: @andreareginato @tomalex0 @PuKoren
